### PR TITLE
JITB-4: Better DEBUG logging

### DIFF
--- a/jitb/jitb_args.py
+++ b/jitb/jitb_args.py
@@ -3,10 +3,13 @@
 import argparse
 # Third Party
 # Local
+from jitb.jitb_logger import Logger
 
 
 def parse_args() -> tuple:
     """Parse the command line arguments and return the room code and username.
+
+    Sets the logger to DEBUG level if debug command line argument is provided.
 
     Returns:
         A tuple containing the (room_code, username).
@@ -17,7 +20,12 @@ def parse_args() -> tuple:
                         required=True)
     parser.add_argument('-u', '--user', action='store', help='The Jackbox Games name',
                         required=True)
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Log debug messages to /tmp/jitb_YYYYMMDD_HHMMSS.log', required=False)
     args = parser.parse_args()
+
+    # SETUP LOG
+    Logger.initialize(debugging=args.debug)
 
     # DONE
     return tuple((args.room, args.user))

--- a/jitb/jitb_globals.py
+++ b/jitb/jitb_globals.py
@@ -12,7 +12,6 @@ OPENAI_KEY_ENV_VAR: Final[str] = 'OPENAI_API_KEY'
 
 # List of Character accessible names for the Jackbox Games Quiplash 3 avatars
 # buttons = test.find_elements(By.XPATH, '//button')
-# print(buttons[0].accessible_name)
 JBG_QUIP3_CHAR_NAMES: Final[List] = ['Purple', 'Blue', 'Teal', 'Green', 'Yellow', 'Orange',
                                      'Red', 'Pink', 'Star', 'Triclops', 'Kitten', 'Coffin',
                                      'Cactus', 'Moon', 'Tear', 'Poop']

--- a/jitb/jitb_logger.py
+++ b/jitb/jitb_logger.py
@@ -72,8 +72,6 @@ class Logger():
         # SETUP
         logging.addLevelName(LogLevel.JITB, 'DEBUGGING')
         Logger._filename = _create_filename()
-        # print(f'FILENAME: {Logger._filename}')  # DEBUGGING
-        # print(f'DEBUG: {debugging}')  # DEBUGGING
 
         if debugging:
             normal = logging.FileHandler(Logger._filename)
@@ -111,8 +109,6 @@ class Logger():
             logger: Logger name if needed. Defaults to pt_logger
         """
         Logger._check_logger()
-        # print(dir(logging.getLogger(logger)))  # DEBUGGING
-        # logging.getLogger(logger).debug(message)
         Logger.log(level=LogLevel.JITB, message=message, logger=logger)
 
     def error(message: str, logger: str = __name__) -> None:

--- a/jitb/jitb_logger.py
+++ b/jitb/jitb_logger.py
@@ -1,4 +1,10 @@
-"""Standardize logging on behalf of the package."""
+"""Standardize logging on behalf of the package.
+
+Using the --debug command line argument will duplicate any log output, and add debug messages,
+to /tmp/jitb_YYYYMMDD_HHMMSS.log.
+
+clear; tail -f `ls /tmp/jitb_* | tail -n 1`
+"""
 # Standard
 from datetime import datetime
 from enum import IntEnum
@@ -9,9 +15,7 @@ import sys
 # Local
 
 
-# clear; tail -f `ls /tmp/jitb_* | tail -n 1`
-
-
+# pylint: disable=too-few-public-methods, no-self-argument
 class LogLevel(IntEnum):
     """Defines logging levels."""
     DEBUG = logging.DEBUG     # Debug messages
@@ -143,6 +147,7 @@ class Logger():
         """
         logging.getLogger(logger).log(level, message)
 
+    # pylint: disable=no-method-argument
     def _check_logger() -> None:
         """Verify the logger was initialized."""
         if Logger._initialized is False:

--- a/jitb/jitb_logger.py
+++ b/jitb/jitb_logger.py
@@ -1,0 +1,166 @@
+"""Standardize logging on behalf of the package."""
+# Standard
+from datetime import datetime
+from enum import IntEnum
+import logging
+import os
+import sys
+# Third Party
+# Local
+
+
+# clear; tail -f `ls /tmp/jitb_* | tail -n 1`
+
+
+class LogLevel(IntEnum):
+    """Defines logging levels."""
+    DEBUG = logging.DEBUG     # Debug messages
+    ERROR = logging.ERROR     # Error messages
+    INFO = logging.INFO       # Standard messages
+    JITB = logging.DEBUG + 5  # JITB DEBUG logging
+
+
+class DebugHandler(logging.Filter):
+    """Filters what can be logger by a specific logger."""
+    def filter(self, record):
+        return record.levelno in (logging.DEBUG,)
+
+
+class ErrorHandler(logging.Filter):
+    """Filters what can be logger by a specific logger."""
+    def filter(self, record):
+        return record.levelno in (logging.ERROR,)
+
+
+class InfoHandler(logging.Filter):
+    """Filters what can be logger by a specific logger."""
+    def filter(self, record):
+        return record.levelno in (logging.INFO,)
+
+
+class JitbHandler(logging.Filter):
+    """Filters what can be logger by a specific logger."""
+    def filter(self, record):
+        return record.levelno in (LogLevel.JITB,)
+
+
+class Logger():
+    """Logging class for the package."""
+
+    _initialized = False  # Logging subsystem status
+    _filename = ''        # Absolute debug log filename
+
+    @staticmethod
+    def initialize(debugging: bool = False) -> None:
+        """Initializes the logging subsystem.
+
+        Args:
+            debug: [Optional] If True, sets the logging level to DEBUG and logs to
+                /tmp/jitb_YYYYMMDD_HHMMSS.log.
+
+        Function is optional as the logging class auto-initializes if called without initialization
+        """
+        # LOCAL VARIABLES
+        debug = None                       # JITB Debug stream handler
+        error = None                       # Error stream handler
+        normal = None                      # Info stream handler
+        root_logger = logging.getLogger()  # Root logger
+        # Message formatter
+        formatter = logging.Formatter(fmt='[%(asctime)s.%(msecs)03d] %(levelname)-9s - %(message)s',
+                                      datefmt='%Y-%m-%d %H:%M:%S')
+
+        # SETUP
+        logging.addLevelName(LogLevel.JITB, 'DEBUGGING')
+        Logger._filename = _create_filename()
+        # print(f'FILENAME: {Logger._filename}')  # DEBUGGING
+        # print(f'DEBUG: {debugging}')  # DEBUGGING
+
+        if debugging:
+            normal = logging.FileHandler(Logger._filename)
+            normal.addFilter(InfoHandler())
+            normal.setFormatter(formatter)
+            normal.setLevel(logging.INFO)
+
+            # Separate and distinct from Logger.DEBUG because good, bad, or indifferent...
+            # Selenium uses DEBUG for very verbose logging
+            debug = logging.FileHandler(Logger._filename)
+            debug.addFilter(JitbHandler())
+            debug.setFormatter(formatter)
+            debug.setLevel(LogLevel.JITB)
+
+            error = logging.FileHandler(Logger._filename)
+            error.addFilter(ErrorHandler())
+            error.setFormatter(formatter)
+            error.setLevel(logging.ERROR)
+
+            root_logger.addHandler(normal)
+            root_logger.addHandler(debug)
+            root_logger.addHandler(error)
+            root_logger.setLevel(LogLevel.JITB)
+        else:
+            root_logger.setLevel(logging.INFO)
+
+        # DONE
+        Logger._initialized = True
+
+    def debug(message: str, logger: str = __name__) -> None:
+        """Log debug level messages.
+
+        Args:
+            message: Message to log
+            logger: Logger name if needed. Defaults to pt_logger
+        """
+        Logger._check_logger()
+        # print(dir(logging.getLogger(logger)))  # DEBUGGING
+        # logging.getLogger(logger).debug(message)
+        Logger.log(level=LogLevel.JITB, message=message, logger=logger)
+
+    def error(message: str, logger: str = __name__) -> None:
+        """Log error level messages.
+
+        Args:
+            message: Message to log
+            logger: Logger name if needed. Defaults to pt_logger
+        """
+        print(message, file=sys.stderr)
+        Logger._check_logger()
+        logging.getLogger(logger).error(message)
+
+    def info(message: str, logger: str = __name__) -> None:
+        """Log info level messages.
+
+        Args:
+            message: Message to log
+            logger: Logger name if needed. Defaults to pt_logger
+        """
+        print(message, file=sys.stdout)
+        Logger._check_logger()
+        logging.getLogger(logger).info(message)
+
+    def log(level: LogLevel, message: str = '', logger: str = __name__) -> None:
+        """Log on behalf of PreTool.
+
+        Args:
+            level: Priority level of message
+            message: Message to log
+            logger: Logger name if needed. Defaults to pt_logger
+        """
+        logging.getLogger(logger).log(level, message)
+
+    def _check_logger() -> None:
+        """Verify the logger was initialized."""
+        if Logger._initialized is False:
+            raise RuntimeError('Call Logger.initialize() first!')
+
+
+def _create_filename() -> str:
+    """Determine filename to use for logging."""
+    # LOCAL VARAIBLES
+    abs_log_filename = ''  # Absolute filename of the log to use
+    now = datetime.now()   # Current date and time
+
+    # CREATE IT
+    abs_log_filename = os.path.join('/tmp', f'jitb_{now.strftime("%Y%m%d_%H%M%S")}.log')
+
+    # DONE
+    return abs_log_filename

--- a/jitb/jitb_main.py
+++ b/jitb/jitb_main.py
@@ -1,6 +1,5 @@
 """Defines the entry-point function for this package."""
 # Standard
-import sys
 # Third Party
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 # Local

--- a/jitb/jitb_main.py
+++ b/jitb/jitb_main.py
@@ -5,6 +5,7 @@ import sys
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 # Local
 from jitb.jitb_args import parse_args
+from jitb.jitb_logger import Logger
 from jitb.jitb_openai import JitbAi
 from jitb.jitb_website import play_the_game
 
@@ -39,4 +40,4 @@ def main() -> int:
 
 def _print_exception(error: Exception) -> None:
     """Print an exception message to stderr."""
-    print(repr(error), file=sys.stderr)
+    Logger.error(repr(error))

--- a/jitb/jitb_openai.py
+++ b/jitb/jitb_openai.py
@@ -10,6 +10,7 @@ import sys
 from openai import OpenAI
 # Local
 from jitb.jitb_globals import OPENAI_KEY_ENV_VAR
+from jitb.jitb_logger import Logger
 
 
 class JitbAi:
@@ -128,7 +129,7 @@ class JitbAi:
             for _ in range(3 - len(answers)):
                 answers.append('')
         elif len(answers) > 3:
-            print(f'OpenAI generated more than just three lines here {answers}')  # DEBUGGING
+            Logger.debug(f'OpenAI generated more than just three lines here {answers}')
             answers = self._extract_thriplash_answer(answers=answers, length_limit=length_limit)
         # Polish the format
         answers = self._polish_thriplash_answers(answers=answers, length_limit=length_limit)
@@ -222,18 +223,18 @@ class JitbAi:
         # INPUT VALIDATION
         if self._failed_request(answer):
             favorite = _randomize_choice(choices=choices)
-            print(f'OpenAI failed with {answer} so {favorite} was chosen randomly')  # DEBUGGING
+            Logger.debug(f'OpenAI failed with {answer} so {favorite} was chosen randomly')
         # EXTRACT IT
         elif answer in choices.keys():
             favorite = choices[answer]  # Sometimes OpenAI follows instructions
-            print(f'OpenAI followed instructions and {favorite} was chosen')  # DEBUGGING
+            Logger.debug(f'OpenAI followed instructions and {favorite} was chosen')
         elif len(answer) != len(list(choices.keys())[0]) and answer[0] in choices.keys():
             favorite = choices[answer[0]]  # Sometimes OpenAI likes to add words
-            print(f'OpenAI added words but we extracted {favorite} from {answer}')  # DEBUGGING
+            Logger.debug(f'OpenAI added words but we extracted {favorite} from {answer}')
         else:
             # Did OpenAI give a response that wasn't a choice without failing the request?!
             favorite = _randomize_choice(choices=choices)
-            print(f'OpenAI went crazy with {answer} so {favorite} was chosen randomly')  # DEBUGGING
+            Logger.debug(f'OpenAI went crazy with {answer} so {favorite} was chosen randomly')
 
         # DONE
         return favorite

--- a/jitb/jitb_website.py
+++ b/jitb/jitb_website.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.by import By
 import selenium
 # Local
 from jitb.jitb_globals import JBG_QUIP3_CHAR_NAMES, JbgQuip3IntPages, JITB_POLL_RATE
+from jitb.jitb_logger import Logger
 from jitb.jitb_openai import JitbAi
 
 
@@ -62,7 +63,7 @@ def answer_thriplash(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     # DONE
     if not clicked_it:
         raise RuntimeError('Did not answer the Thriplash prompt')
-    print(f'ANSWERED {prompt_text} with: {", ".join(gen_answers)}!')  # DEBUGGING
+    Logger.debug(f'ANSWERED {prompt_text} with: {", ".join(gen_answers)}!')
 
 
 def join_room(room_code: str, username: str) -> selenium.webdriver.chrome.webdriver.WebDriver:
@@ -215,7 +216,7 @@ def _answer_prompt(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     # DONE
     if not clicked_it:
         raise RuntimeError('Did not answer the prompt')
-    print(f'ANSWERED {prompt_text} with {answer}!')  # DEBUGGING
+    Logger.debug(f'ANSWERED {prompt_text} with {answer}!')
     return prompt_text
 
 
@@ -464,7 +465,7 @@ def _vote_answer(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     if prompt_text and prompt_text != last_prompt and not clicked_it:
         raise RuntimeError('Did not vote an answer')
     if button:
-        print(f'VOTED {favorite} for {prompt_text}!')  # DEBUGGING
+        Logger.debug(f'VOTED {favorite} for {prompt_text}!')
     return prompt_text
 
 


### PR DESCRIPTION
Not only did I improve DEBUG logging, I improved logging overall.
Standard output/error logging stayed the same.  The new `--debug` option duplicates that output and adds DEBUG output to a `/tmp/jitb_YYYYMMDD_HHMMSS.log` file.
Transitioned all legacy logging to use the new Logger.