### PR TITLE
JITB-25: Formalize releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial support for Jackbox Games Quiplash 2, Quiplash 3, and Joke Boat.
+- Release of the jitb package as a wheel.
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+## [Links]
+

--- a/README.md
+++ b/README.md
@@ -5,21 +5,22 @@ Connecting Jackbox Games to the OpenAI API in Python3
 
 The current [OpenAi API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api) being used.
 
+### Supported Jackbox Games
+
+* [Joke Boat](https://www.jackboxgames.com/games/joke-boat)
+* [Quiplash 2](https://www.jackboxgames.com/games/quiplash-2-interlashional)
+* [Quiplash 3](https://www.jackboxgames.com/games/quiplash-3)
+
 ## INSTRUCTIONS
 
-1. Clone the repo
-2. `cd jack-in-the-box`
-3. Install dependencies
-   - `pip install selenium`
-   - `pip install --upgrade openai`
-   - `pip install Unidecode`
-   - Requirements.txt coming ~soon~ at all?
-4. [Setup your OpenAI API Key](https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key)
-5. Start [Jackbox Games](https://www.jackboxgames.com/) [Quiplash 3](https://www.jackboxgames.com/games/the-jackbox-party-starter/quiplash-3-party-starter)
-6. Get one human signed in (JITB is not a great VIP)
-7. `python -m jitb --room <ROOM_CODE> --user JITB`
-8. Start the game   
+1. Download a release wheel from [releases](https://github.com/hark130/jack-in-the-box/releases)
+2. `pip install jitb-X.Y.Z-py3-none-any.whl`
+3. [Setup your OpenAI API Key](https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key)
+4. Start a supported [Jackbox Game](https://www.jackboxgames.com/)
+5. Get one human signed in (JITB will not function as the VIP)
+6. `jitb --user JITB --room <ROOM_CODE>`
+7. Start the game
 
 ## USAGE
 
-`python -m jitb --help`
+`jitb --help`

--- a/jitb/__init__.py
+++ b/jitb/__init__.py
@@ -1,0 +1,4 @@
+"""Connecting Jackbox Games to the OpenAI API in Python.
+
+Usage: jitb --help
+"""

--- a/jitb/__main__.py
+++ b/jitb/__main__.py
@@ -1,4 +1,5 @@
 """Entry level module for the package."""
+
 # Standard
 import sys
 # Third Party
@@ -6,5 +7,10 @@ import sys
 from jitb.jitb_main import main
 
 
+def run_jitb() -> int:
+    """Wraps the call to main() translating results into exit codes and exits."""
+    return main()
+
+
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(run_jitb())

--- a/jitb/jbgames/jbg_jb.py
+++ b/jitb/jbgames/jbg_jb.py
@@ -338,7 +338,7 @@ class JbgJb(JbgAbc):
         # AI generated answer
         messages = [{'role': 'user', 'content': prompt}]
         answer = self._ai_obj.create_content(messages=messages, add_base_msgs=False,
-                                              max_tokens=100)
+                                             max_tokens=100)
         answers = _split_and_strip_answers(answer, '\n')
 
         # STORE IT

--- a/jitb/jitb_args.py
+++ b/jitb/jitb_args.py
@@ -11,8 +11,9 @@ def parse_args() -> tuple:
     Returns:
         A tuple containing the (room_code, username, debug).
     """
-    parser = argparse.ArgumentParser(prog='Jack in the Box',
-                                     description='Connecting Jackbox Games to the OpenAI API')
+    parser = argparse.ArgumentParser(prog='jitb',
+                                     description='Jack in the Box (JITB): Connecting Jackbox '
+                                                 'Games to the OpenAI API.')
     parser.add_argument('-r', '--room', action='store', help='The Jackbox Games room code',
                         required=True)
     parser.add_argument('-u', '--user', action='store', help='The Jackbox Games name',

--- a/jitb/jitb_openai.py
+++ b/jitb/jitb_openai.py
@@ -76,7 +76,7 @@ class JitbAi:
             self._client = None
 
     def create_content(self, messages: List, add_base_msgs: bool = True,
-                        max_tokens: int = 50) -> str:
+                       max_tokens: int = 50) -> str:
         """Communicate with OpenAI using the API.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+# This configuration file is used to release JITB as a wheel.
+#
+# Usage:
+#   pip install --upgrade build python3.10-venv
+#   python -m build  # From the jack-in-the-box directory
+
+[build-system]
+requires = [ 'setuptools>=61.0' ]
+build-backend = 'setuptools.build_meta'
+
+[project]
+name = 'jitb'
+version = '1.0.0'
+authors = [
+    { name='Joseph Harkleroad', email='hark130@yahoo.com' },
+]
+description = 'Connecting Jackbox Games to the OpenAI API using Python'
+readme = 'README.md'
+requires-python = '>=3.10'
+dynamic = [ 'dependencies' ]
+classifiers = [
+    # Taken from: https://pypi.org/pypi?%3Aaction=list_classifiers
+    'Programming Language :: Python :: 3',
+    'Intended Audience :: Science/Research',
+    'Natural Language :: English',
+    'Operating System :: OS Independent',
+    'Topic :: Games/Entertainment',
+    'Topic :: Scientific/Engineering :: Artificial Intelligence'
+]
+keywords = [ 'Jackbox', 'Games', 'Jack in the Box', 'OpenAI', 'ChatGPT' ]
+
+[project.scripts]
+jitb = 'jitb.__main__:run_jitb'
+
+[project.urls]
+Homepage = 'https://github.com/hark130/jack-in-the-box/tree/main'
+Documentation = 'https://github.com/hark130/jack-in-the-box/wiki'
+Repository = 'https://github.com/hark130/jack-in-the-box'
+Issues = 'https://github.com/hark130/jack-in-the-box/issues'
+#Changelog = ''  # TO DO: DON'T DO NOW... Make it soon
+
+[tool.setuptools.dynamic]
+dependencies = { file = ['requirements.txt'] }
+
+[tool.setuptools.packages.find]
+include = [ 'jitb', 'jitb.jbgames' ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Homepage = 'https://github.com/hark130/jack-in-the-box/tree/main'
 Documentation = 'https://github.com/hark130/jack-in-the-box/wiki'
 Repository = 'https://github.com/hark130/jack-in-the-box'
 Issues = 'https://github.com/hark130/jack-in-the-box/issues'
-#Changelog = ''  # TO DO: DON'T DO NOW... Make it soon
+Changelog = 'https://github.com/hark130/jack-in-the-box/blob/main/CHANGELOG.md'
 
 [tool.setuptools.dynamic]
 dependencies = { file = ['requirements.txt'] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.3     # OpenAI API
+selenium>=4.16  # Controls the Chrome browser launched by JITB
+Unidecode>=1.3  # Used to clean response strings from OpenAI's API


### PR DESCRIPTION
- Started a `CHANGELOG`
- Updated the `README`
- Updated `__main__` so JITB can run from the CLI
- Implemented a build system
    - `pyproject.toml`
    - `requirements.txt`
- Cleaned up the code base
- Improved the `--help` message
- Wrote and import help message (see: `python -c "import jitb; help(jitb)"`)