### PR TITLE
JITB-40: Refactor validation into a SPOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for manual login (e.g., Twitch-enabled games)
+- New `jitb_validation` module to standardize JITB-specific input validation
 
 ### Changed
 
 - Argument parser now utilizes commands: automatic, manual
+- Extricated module-local, private validation functions into `jitb_validation` as appropriate
+- All JITB validation is either handled by `hobo.validation` or `jitb_validation`
+- Many of the "bad input" exception messages have changed now input validation has changed
 
 ### Deprecated
 
 ### Fixed
+
+- Exception message on `jitb_webdriver._validate_bool()` when it got promoted to `jitb_validation.validate_bool()`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ JITB uses this [OpenAi API](https://platform.openai.com/docs/guides/text-generat
 	- `jitb auto --user JITB --room <ROOM_CODE>` (v2 or later)
 1. Start the game
 
-
 ## USAGE
 
 `jitb --help`

--- a/jitb/jbgames/jbg_abc.py
+++ b/jitb/jbgames/jbg_abc.py
@@ -4,6 +4,7 @@
 from abc import ABC, abstractmethod
 from typing import Final, List
 # Third Party
+from hobo.validation import validate_string, validate_type
 from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 from selenium.webdriver.common.by import By
 import selenium
@@ -11,6 +12,7 @@ import selenium
 from jitb.jbgames.jbg_page_ids import JbgPageIds
 from jitb.jitb_logger import Logger
 from jitb.jitb_openai import JitbAi
+from jitb.jitb_validation import validate_bool
 
 
 # List of observed errors reported by Jackbox Games html
@@ -157,8 +159,7 @@ class JbgAbc(ABC):
         temp_we = None  # Temp web element object
 
         # CHECK IT
-        if not isinstance(web_driver, selenium.webdriver.chrome.webdriver.WebDriver):
-            raise TypeError(f'Invalid data type of {type(web_driver)} for the web_driver')
+        validate_web_driver(web_driver=web_driver)
         # Check for errors
         for error in ERROR_LIST:
             if error.lower() in web_driver.page_source.lower():
@@ -208,17 +209,12 @@ class JbgAbc(ABC):
             ValueError: An internal attribute contains an invalid value.
         """
         # JitbAi
-        if not isinstance(self._ai_obj, JitbAi):
-            raise TypeError(f'Invalid data type of {type(self._ai_obj)} for the AI object')
+        validate_type(self._ai_obj, 'ai_obj', JitbAi)
         # Avatar Chosen
-        if not isinstance(self._avatar_chosen, bool):
-            raise TypeError(f'Invalid data type of {type(self._avatar_chosen)} for "avatar chosen"')
+        validate_bool(self._avatar_chosen, 'Internal attribute _avatar_chosen')
         # Username
         if self._username is not None:
-            if not isinstance(self._username, str):
-                raise TypeError(f'Invalid data type of {type(self._username)} for the username')
-            if not self._username:
-                raise ValueError('The username may not be blank')
+            validate_string(self._username, 'username', can_be_empty=False)
         # Last page
         _validate_page_id(page_id=self._last_page, var_name='last page')
         # Current page
@@ -232,5 +228,4 @@ def _validate_page_id(page_id: JbgPageIds, var_name: str) -> None:
     Raises:
         TypeError: page_id is the wrong data type.
     """
-    if not isinstance(page_id, JbgPageIds):
-        raise TypeError(f'JbgPageIds "{var_name}" is an invalid data type of {type(page_id)}')
+    validate_type(page_id, 'page_id', JbgPageIds)

--- a/jitb/jbgames/jbg_abc.py
+++ b/jitb/jbgames/jbg_abc.py
@@ -12,7 +12,7 @@ import selenium
 from jitb.jbgames.jbg_page_ids import JbgPageIds
 from jitb.jitb_logger import Logger
 from jitb.jitb_openai import JitbAi
-from jitb.jitb_validation import validate_bool
+from jitb.jitb_validation import validate_bool, validate_web_driver
 
 
 # List of observed errors reported by Jackbox Games html

--- a/jitb/jbgames/jbg_abc.py
+++ b/jitb/jbgames/jbg_abc.py
@@ -228,4 +228,4 @@ def _validate_page_id(page_id: JbgPageIds, var_name: str) -> None:
     Raises:
         TypeError: page_id is the wrong data type.
     """
-    validate_type(page_id, 'page_id', JbgPageIds)
+    validate_type(page_id, var_name, JbgPageIds)

--- a/jitb/jitb_misc.py
+++ b/jitb/jitb_misc.py
@@ -8,6 +8,7 @@ import unidecode
 # Third Party
 # Local
 from jitb.jitb_globals import TEMP_DIR_DEF_NIX, TEMP_DIR_DEF_WIN, TEMP_DIR_ENV_VARS
+from jitb.jitb_validation import validate_string
 
 
 def char_filter(dirty_str: str):
@@ -30,7 +31,7 @@ def clean_string(dirty_str: str) -> str:
     Returns:
         A clean version of dirty_str.
     """
-    return "".join(char_filter(dirty_str))
+    return ''.join(char_filter(dirty_str))
 
 
 def clean_up_string(dirty_string: str, replace_char: str = ' ') -> str:
@@ -64,10 +65,7 @@ def convert_str_to_int(int_string: str) -> None:
     integer = None  # Converted integer from the int_string
 
     # INPUT VALIDATION
-    if not isinstance(int_string, str):
-        raise TypeError(f'The int_string argument must be a string instead of a {type(int_string)}')
-    if not int_string:
-        raise ValueError('The int_string may not be empty')
+    validate_string(int_string, 'int_string', may_be_empty=False)
 
     # CONVERT IT
     try:

--- a/jitb/jitb_misc.py
+++ b/jitb/jitb_misc.py
@@ -6,9 +6,9 @@ import re
 import unicodedata
 import unidecode
 # Third Party
+from hobo.validation import validate_string
 # Local
 from jitb.jitb_globals import TEMP_DIR_DEF_NIX, TEMP_DIR_DEF_WIN, TEMP_DIR_ENV_VARS
-from jitb.jitb_validation import validate_string
 
 
 def char_filter(dirty_str: str):

--- a/jitb/jitb_misc.py
+++ b/jitb/jitb_misc.py
@@ -65,7 +65,7 @@ def convert_str_to_int(int_string: str) -> None:
     integer = None  # Converted integer from the int_string
 
     # INPUT VALIDATION
-    validate_string(int_string, 'int_string', may_be_empty=False)
+    validate_string(int_string, 'int_string', can_be_empty=False)
 
     # CONVERT IT
     try:

--- a/jitb/jitb_openai.py
+++ b/jitb/jitb_openai.py
@@ -85,7 +85,7 @@ class JitbAi:
             new_content: New 'content' entry.
         """
         # INPUT VALIDATION
-        validate_string(new_content, 'new_content', may_be_empty=True)
+        validate_string(new_content, 'new_content', can_be_empty=True)
 
         # CHANGE IT
         self._base_messages[0][BASE_MSG_CONTENT_KEY] = new_content

--- a/jitb/jitb_openai.py
+++ b/jitb/jitb_openai.py
@@ -9,7 +9,7 @@ import random
 import string
 import sys
 # Third Party
-from hobo.validation import validate_list, validate_string
+from hobo.validation import validate_list, validate_string, validate_type
 from openai import OpenAI
 # Local
 from jitb.jitb_globals import DEFAULT_SYSTEM_CONTENT, OPENAI_KEY_ENV_VAR

--- a/jitb/jitb_openai.py
+++ b/jitb/jitb_openai.py
@@ -9,11 +9,13 @@ import random
 import string
 import sys
 # Third Party
+from hobo.validation import validate_list, validate_string
 from openai import OpenAI
 # Local
 from jitb.jitb_globals import DEFAULT_SYSTEM_CONTENT, OPENAI_KEY_ENV_VAR
 from jitb.jitb_logger import Logger
 from jitb.jitb_misc import clean_up_string
+from jitb.jitb_validation import validate_pos_int
 
 
 # Minimum number of underscores to be considered a fill-in-the-blank
@@ -83,8 +85,7 @@ class JitbAi:
             new_content: New 'content' entry.
         """
         # INPUT VALIDATION
-        if not isinstance(new_content, str):
-            raise TypeError(f'Invalid new_content data type of {type(new_content)}')
+        validate_string(new_content, 'new_content', may_be_empty=True)
 
         # CHANGE IT
         self._base_messages[0][BASE_MSG_CONTENT_KEY] = new_content
@@ -346,13 +347,11 @@ class JitbAi:
         new_answers = answers  # Shiny, newly polished strings
 
         # INPUT VALIDATION
-        if not isinstance(answers, list):
-            raise TypeError('answers is not a list')
+        validate_list(answers, 'answers', can_be_empty=False)
         if len(answers) > 3 or not answers:
             raise ValueError('answers list is the wrong size')
         for answer in answers:
-            if not isinstance(answer, str):
-                raise TypeError('Found a non-string inside answers list')
+            validate_string(answer, 'answers list entry')
 
         # POLISH IT
         # Polish the format
@@ -416,14 +415,13 @@ def polish_answer(prompt: str, answer: str, length_limit: int, original_answer: 
     final_run = False    # Final call in the recursive call stack
 
     # INPUT VALIDATION
-    _validate_string(prompt, 'prompt')
-    _validate_string(answer, 'answer')
-    if not isinstance(length_limit, int):
-        raise TypeError(f'The length_limit argument must be an int instead of {type(length_limit)}')
+    validate_string(prompt, 'prompt')
+    validate_string(answer, 'answer')
+    validate_type(length_limit, 'length_limit', int)
     if length_limit < 1:
         raise ValueError(f'The length_limit must be a positive number instead of {length_limit}')
     if original_answer:
-        _validate_string(original_answer, 'original_answer')
+        validate_string(original_answer, 'original_answer')
     else:
         original_answer = answer  # This is the first call
 
@@ -483,9 +481,9 @@ def remove_answer_overlap(prompt: str, answer: str, min_len: int = MIN_FITB_LEN)
     regex_pattern = r''  # Use this regex split the prompt
 
     # INPUT VALIDATION
-    _validate_string(prompt, 'prompt')
-    _validate_string(answer, 'answer')
-    _validate_pos_int(min_len, 'min_len')
+    validate_string(prompt, 'prompt')
+    validate_string(answer, 'answer')
+    validate_pos_int(min_len, 'min_len')
 
     # SPLIT IT
     # Matches on any min_len number of underscores anywhere
@@ -545,8 +543,8 @@ def remove_punctuation(prompt: str, answer: str, min_len: int = MIN_FITB_LEN) ->
     blank = '_' * min_len  # Fill-in-the-blank substring
 
     # INPUT VALIDATION
-    _validate_string(prompt, 'prompt')
-    _validate_string(answer, 'answer')
+    validate_string(prompt, 'prompt')
+    validate_string(answer, 'answer')
 
     # REMOVE IT
     if not answer.endswith('!') and not prompt.endswith(blank):
@@ -621,37 +619,3 @@ def _match_phrase(needle: str, haystack: str, threshold: float = 0.75) -> bool:
 def _randomize_choice(choices: dict) -> str:
     """Randomize one of the values from choices."""
     return random.choice(list(choices.values()))
-
-
-def _validate_pos_int(in_int: int, name: str) -> None:
-    """Validate input on behalf of this module's API functions.
-
-    Args:
-        in_int: Input to validate.
-        name: Name of the original variable to us in crafting the Exception message.
-
-    Raises:
-        TypeError: Bad data type.
-        ValueError: Integer not positive.
-    """
-    if not isinstance(in_int, int):
-        raise TypeError(f'Invalid data type for {name} argument: {type(in_int)}')
-    if in_int < 1:
-        raise ValueError(f'{name.capitalize()} must be positive')
-
-
-def _validate_string(in_str: str, name: str) -> None:
-    """Validate input on behalf of this module's API functions.
-
-    Args:
-        in_str: Input to validate.
-        name: Name of the original variable to us in crafting the Exception message.
-
-    Raises:
-        TypeError: Bad data type.
-        ValueError: Empty string.
-    """
-    if not isinstance(in_str, str):
-        raise TypeError(f'Invalid data type for {name} argument: {type(in_str)}')
-    if not in_str:
-        raise ValueError(f'{name.capitalize()} may not be empty')

--- a/jitb/jitb_selenium.py
+++ b/jitb/jitb_selenium.py
@@ -10,6 +10,7 @@ import selenium
 # Local
 from jitb.jitb_logger import Logger
 from jitb.jitb_misc import convert_str_to_int
+from jitb.jitb_validation import validate_web_driver
 
 
 DEFAULT_BUTTON_BY: Final[str] = By.XPATH        # We find buttons by XPath, by default.
@@ -309,7 +310,7 @@ def _validate_wd_input(web_driver: selenium.webdriver.chrome.webdriver.WebDriver
     """Validate the input on behalf of API functions in this module."""
     # INPUT VALIDATION
     # web_driver
-    validate_type(web_driver, 'webdriver', selenium.webdriver.chrome.webdriver.WebDriver)
+    validate_web_driver(web_driver=web_driver)
     _validate_common_args(by_arg=by_arg, value=value)
 
 

--- a/jitb/jitb_selenium.py
+++ b/jitb/jitb_selenium.py
@@ -3,6 +3,7 @@
 # Standard
 from typing import Any, Final, List
 # Third Party
+from hobo.validation import validate_string, validate_type
 from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 from selenium.webdriver.common.by import By
 import selenium
@@ -294,14 +295,13 @@ def _validate_common_args(by_arg: str, value: str) -> None:
     """Validate the cross-section of this module's API functions."""
     # INPUT VALIDATION
     # by_arg
-    if not isinstance(by_arg, str):
-        raise TypeError(f'Invalid data type of {type(by_arg)} for the by_arg')
+    validate_string(by_arg, 'by_arg', can_be_empty=False)
     if not hasattr(By, by_arg.replace(' ', '_').upper()):
         raise ValueError(f'Invalid by_arg value of {by_arg}.  Use By value from '
                          'the selenium.webdriver.common.by module')
     # value
-    if not isinstance(value, str) and value is not None:
-        raise TypeError(f'Invalid data type of {type(value)} for the value')
+    if value is not None:
+        validate_string(value, 'value', can_be_empty=True)
 
 
 def _validate_wd_input(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
@@ -309,10 +309,7 @@ def _validate_wd_input(web_driver: selenium.webdriver.chrome.webdriver.WebDriver
     """Validate the input on behalf of API functions in this module."""
     # INPUT VALIDATION
     # web_driver
-    if not web_driver:
-        raise TypeError('Web driver may not be None')
-    if not isinstance(web_driver, selenium.webdriver.chrome.webdriver.WebDriver):
-        raise TypeError(f'Invalid data type of {type(web_driver)} for the web_driver')
+    validate_type(web_driver, 'webdriver', selenium.webdriver.chrome.webdriver.WebDriver)
     _validate_common_args(by_arg=by_arg, value=value)
 
 
@@ -321,8 +318,5 @@ def _validate_we_input(web_element: selenium.webdriver.remote.webelement.WebElem
     """Validate the input on behalf of API functions in this module."""
     # INPUT VALIDATION
     # web_element
-    if not web_element:
-        raise TypeError('Web element may not be None')
-    if not isinstance(web_element, selenium.webdriver.remote.webelement.WebElement):
-        raise TypeError(f'Invalid data type of {type(web_element)} for the web_element')
+    validate_type(web_element, 'web_element', selenium.webdriver.remote.webelement.WebElement)
     _validate_common_args(by_arg=by_arg, value=value)

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -68,7 +68,4 @@ def validate_pos_int(in_int: int, name: str) -> None:
 
 def validate_web_driver(web_driver: selenium.webdriver.chrome.webdriver.WebDriver) -> None:
     """Validate a web driver."""
-    if not web_driver:
-        raise TypeError('Web driver can not be of type None')
-    if not isinstance(web_driver, selenium.webdriver.chrome.webdriver.WebDriver):
-        raise TypeError(f'Invalid web_driver data type of {type(web_driver)}')
+    validate_type(web_driver, 'web_driver', selenium.webdriver.chrome.webdriver.WebDriver)

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 # Third Party
 from hobo.validation import validate_string, validate_type
 import selenium
+import selenium.webdriver
 # Local
 
 
@@ -23,7 +24,7 @@ def validate_bool(value: str, name: str) -> None:
 
 def validate_element_type(element_type: str) -> None:
     """Validate element_type arguments on behalf of this module."""
-    validate_string(element_type, 'element_type', may_be_empty=False)
+    validate_string(element_type, 'element_type', can_be_empty=False)
 
 
 def validate_game(game: str, games: Dict[str, Any]) -> None:

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -1,0 +1,44 @@
+"""Defines standard validation for the package."""
+
+# Standard
+# Third Party
+import selenium
+# Local
+
+
+def validate_bool(value: str, name: str) -> None:
+    """Validates boolean values on behalf of this module.
+
+    Args:
+        value: The variable to check.
+        name: The name of the original arugment being validated (used in exception messages).
+    """
+    if not isinstance(value, bool):
+        raise TypeError(f'The {name} value must be a string instead of type {type(value)}')
+
+
+def validate_element_type(element_type: str) -> None:
+    """Validate element_type arguments on behalf of this module."""
+    validate_string(element_type, 'element_type', may_be_empty=False)
+
+
+def validate_string(string: str, name: str, may_be_empty: bool = False) -> None:
+    """Validates strings on behalf of this module.
+
+    Args:
+        string: The value of the string to check.
+        name: The name of the original arugment being validated (used in exception messages).
+        may_be_empty: Optional; If True, string may not be empty.
+    """
+    if not isinstance(string, str):
+        raise TypeError(f'The {name} value must be a string instead of type {type(string)}')
+    if not string and not may_be_empty:
+        raise ValueError(f'The {name} may not be empty')
+
+
+def validate_web_driver(web_driver: selenium.webdriver.chrome.webdriver.WebDriver) -> None:
+    """Validate a web driver."""
+    if not web_driver:
+        raise TypeError('Web driver can not be of type None')
+    if not isinstance(web_driver, selenium.webdriver.chrome.webdriver.WebDriver):
+        raise TypeError(f'Invalid web_driver data type of {type(web_driver)}')

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -1,9 +1,12 @@
-"""Defines standard validation for the package."""
+"""Defines standard validation for the package.
+
+See help(hobo.validation) for basic validation functionality.
+"""
 
 # Standard
 from typing import Any, Dict
 # Third Party
-from hobo.validation import validate_type
+from hobo.validation import validate_string, validate_type
 import selenium
 # Local
 
@@ -15,8 +18,7 @@ def validate_bool(value: str, name: str) -> None:
         value: The variable to check.
         name: The name of the original arugment being validated (used in exception messages).
     """
-    if not isinstance(value, bool):
-        raise TypeError(f'The {name} value must be a string instead of type {type(value)}')
+    validate_type(value, name, bool)
 
 
 def validate_element_type(element_type: str) -> None:
@@ -47,18 +49,20 @@ def validate_game(game: str, games: Dict[str, Any]) -> None:
         raise RuntimeError(f'JITB does not yet support {game}')
 
 
-def validate_string(string: str, name: str, may_be_empty: bool = False) -> None:
-    """Validates strings on behalf of this module.
+def validate_pos_int(in_int: int, name: str) -> None:
+    """Validate input on behalf of this module's API functions.
 
     Args:
-        string: The value of the string to check.
-        name: The name of the original arugment being validated (used in exception messages).
-        may_be_empty: Optional; If True, string may not be empty.
+        in_int: Input to validate.
+        name: Name of the original variable to us in crafting the Exception message.
+
+    Raises:
+        TypeError: Bad data type.
+        ValueError: Integer not positive.
     """
-    if not isinstance(string, str):
-        raise TypeError(f'The {name} value must be a string instead of type {type(string)}')
-    if not string and not may_be_empty:
-        raise ValueError(f'The {name} may not be empty')
+    validate_type(in_int, name, int)
+    if in_int < 1:
+        raise ValueError(f'{name.capitalize()} must be positive')
 
 
 def validate_web_driver(web_driver: selenium.webdriver.chrome.webdriver.WebDriver) -> None:

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -41,12 +41,18 @@ def validate_game(game: str, games: Dict[str, Any]) -> None:
     Raises:
         RuntimeError: This game is not supported.
     """
+    # LOCAL VARIABLES
+    game_list = None  # List of the keys from the games dictionary
+
     # INPUT VALIDATION
     validate_string(game, 'game')
     validate_type(games, 'games', dict)
+    game_list = list(games.keys())
+    for game_entry in game_list:
+        validate_string(game_entry, 'games dict key entry', can_be_empty=False)
 
     # VALIDATE GAME
-    if game not in list(games.keys()):
+    if game not in game_list:
         raise RuntimeError(f'JITB does not yet support {game}')
 
 

--- a/jitb/jitb_validation.py
+++ b/jitb/jitb_validation.py
@@ -1,7 +1,9 @@
 """Defines standard validation for the package."""
 
 # Standard
+from typing import Any, Dict
 # Third Party
+from hobo.validation import validate_type
 import selenium
 # Local
 
@@ -20,6 +22,29 @@ def validate_bool(value: str, name: str) -> None:
 def validate_element_type(element_type: str) -> None:
     """Validate element_type arguments on behalf of this module."""
     validate_string(element_type, 'element_type', may_be_empty=False)
+
+
+def validate_game(game: str, games: Dict[str, Any]) -> None:
+    """Validate the game against the dictionary of support games.
+
+    Why this odd validation?  Why is the value type hint Any?  To avoid circular
+    imports.  The expected value type is actually JbgAbc, but that doesn't
+    matter here.
+
+    Args:
+        game: The game to be checked for support.
+        games: A dictionary of games JITB supports.  Only the keys are inspected.
+
+    Raises:
+        RuntimeError: This game is not supported.
+    """
+    # INPUT VALIDATION
+    validate_string(game, 'game')
+    validate_type(games, 'games', dict)
+
+    # VALIDATE GAME
+    if game not in list(games.keys()):
+        raise RuntimeError(f'JITB does not yet support {game}')
 
 
 def validate_string(string: str, name: str, may_be_empty: bool = False) -> None:

--- a/jitb/jitb_webdriver.py
+++ b/jitb/jitb_webdriver.py
@@ -407,7 +407,7 @@ def vote_answers(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
 
     # INPUT VALIDATION
     # All other arguments validated by calls to other module functions
-    validate_string(string=last_prompt, name='last_prompt', can_be_empty=True)
+    validate_string(last_prompt, 'last_prompt', can_be_empty=True)
     validate_type(ai_obj, 'ai_obj', JitbAi)
 
     # WAIT FOR IT

--- a/jitb/jitb_webdriver.py
+++ b/jitb/jitb_webdriver.py
@@ -407,7 +407,7 @@ def vote_answers(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
 
     # INPUT VALIDATION
     # All other arguments validated by calls to other module functions
-    validate_string(string=last_prompt, name='last_prompt', may_be_empty=True)
+    validate_string(string=last_prompt, name='last_prompt', can_be_empty=True)
     validate_type(ai_obj, 'ai_obj', JitbAi)
 
     # WAIT FOR IT
@@ -515,7 +515,7 @@ def _is_page(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
 
     # INPUT VALIDATION
     validate_web_driver(web_driver=web_driver)
-    validate_string(element_name, 'element_name', may_be_empty=False)
+    validate_string(element_name, 'element_name', can_be_empty=False)
     validate_element_type(element_type=element_type)
     _validate_clues(clues=clues)
     validate_bool(clean_string, 'clean_string')
@@ -555,4 +555,4 @@ def _validate_clues(clues: List[str] = None) -> None:
     if clues is not None:
         validate_list(clues, 'clues', can_be_empty=True)
         for clue in clues:
-            validate_string(clue, 'clues list entry', may_be_empty=False)
+            validate_string(clue, 'clues list entry', can_be_empty=False)

--- a/jitb/jitb_webdriver.py
+++ b/jitb/jitb_webdriver.py
@@ -9,7 +9,7 @@ defined in the jitb.jbgames module.
 from typing import Dict, List
 import time
 # Third Party
-from hobo.validation import validate_list, validate_string
+from hobo.validation import validate_list, validate_string, validate_type
 from selenium.common.exceptions import (ElementNotInteractableException, NoSuchElementException,
                                         StaleElementReferenceException)
 from selenium.webdriver.common.by import By
@@ -21,8 +21,7 @@ from jitb.jitb_misc import clean_up_string, convert_str_to_int
 from jitb.jitb_openai import JitbAi
 from jitb.jitb_selenium import (get_buttons, get_web_element, get_web_element_int,
                                 get_web_element_text)
-from jitb.jitb_validation import (validate_bool, validate_element_type, validate_string,
-                                  validate_web_driver)
+from jitb.jitb_validation import validate_bool, validate_element_type, validate_web_driver
 
 
 # Public Module Functions
@@ -409,8 +408,7 @@ def vote_answers(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     # INPUT VALIDATION
     # All other arguments validated by calls to other module functions
     validate_string(string=last_prompt, name='last_prompt', may_be_empty=True)
-    if not isinstance(ai_obj, JitbAi):
-        raise TypeError(f'Invalid type of {type(ai_obj)} for ai_obj argument')
+    validate_type(ai_obj, 'ai_obj', JitbAi)
 
     # WAIT FOR IT
     for _ in range(num_loops):
@@ -554,9 +552,7 @@ def _validate_clues(clues: List[str] = None) -> None:
         TypeError: Bad data type.
         ValueError: Invalid value.
     """
-    if isinstance(clues, list):
+    if clues is not None:
+        validate_list(clues, 'clues', can_be_empty=True)
         for clue in clues:
             validate_string(clue, 'clues list entry', may_be_empty=False)
-    elif clues:
-        raise TypeError(f'Invalid data type for clues: {clues} '
-                        f'(Type: {type(clues)})')

--- a/jitb/jitb_webdriver.py
+++ b/jitb/jitb_webdriver.py
@@ -21,6 +21,8 @@ from jitb.jitb_misc import clean_up_string, convert_str_to_int
 from jitb.jitb_openai import JitbAi
 from jitb.jitb_selenium import (get_buttons, get_web_element, get_web_element_int,
                                 get_web_element_text)
+from jitb.jitb_validation import (validate_bool, validate_element_type, validate_string,
+                                  validate_web_driver)
 
 
 # Public Module Functions
@@ -89,7 +91,7 @@ def get_button_choices(web_driver: selenium.webdriver.chrome.webdriver.WebDriver
     local_exclude = []    # Lower case conversion from exclude
 
     # INPUT VALIDATION
-    _validate_web_driver(web_driver=web_driver)
+    validate_web_driver(web_driver=web_driver)
     if exclude is not None:
         validate_list(validate_this=exclude, param_name='exclude', can_be_empty=False)
         for exclusion in exclude:
@@ -406,7 +408,7 @@ def vote_answers(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
 
     # INPUT VALIDATION
     # All other arguments validated by calls to other module functions
-    _validate_string(string=last_prompt, name='last_prompt', may_be_empty=True)
+    validate_string(string=last_prompt, name='last_prompt', may_be_empty=True)
     if not isinstance(ai_obj, JitbAi):
         raise TypeError(f'Invalid type of {type(ai_obj)} for ai_obj argument')
 
@@ -514,11 +516,11 @@ def _is_page(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     temp_text = ''  # Text from the web element
 
     # INPUT VALIDATION
-    _validate_web_driver(web_driver=web_driver)
-    _validate_string(element_name, 'element_name', may_be_empty=False)
-    _validate_element_type(element_type=element_type)
+    validate_web_driver(web_driver=web_driver)
+    validate_string(element_name, 'element_name', may_be_empty=False)
+    validate_element_type(element_type=element_type)
     _validate_clues(clues=clues)
-    _validate_bool(clean_string, 'clean_string')
+    validate_bool(clean_string, 'clean_string')
 
     # IS IT?
     try:
@@ -541,17 +543,6 @@ def _is_page(web_driver: selenium.webdriver.chrome.webdriver.WebDriver,
     return page
 
 
-def _validate_bool(value: str, name: str) -> None:
-    """Validates boolean values on behalf of this module.
-
-    Args:
-        value: The variable to check.
-        name: The name of the original arugment being validated (used in exception messages).
-    """
-    if not isinstance(value, bool):
-        raise TypeError(f'The {name} value must be a string instead of type {type(value)}')
-
-
 def _validate_clues(clues: List[str] = None) -> None:
     """Validate *_clues arguments on behalf of this module.
 
@@ -565,34 +556,7 @@ def _validate_clues(clues: List[str] = None) -> None:
     """
     if isinstance(clues, list):
         for clue in clues:
-            _validate_string(clue, 'clues list entry', may_be_empty=False)
+            validate_string(clue, 'clues list entry', may_be_empty=False)
     elif clues:
         raise TypeError(f'Invalid data type for clues: {clues} '
                         f'(Type: {type(clues)})')
-
-
-def _validate_element_type(element_type: str) -> None:
-    """Validate element_type arguments on behalf of this module."""
-    _validate_string(element_type, 'element_type', may_be_empty=False)
-
-
-def _validate_string(string: str, name: str, may_be_empty: bool = False) -> None:
-    """Validates strings on behalf of this module.
-
-    Args:
-        string: The value of the string to check.
-        name: The name of the original arugment being validated (used in exception messages).
-        may_be_empty: Optional; If True, string may not be empty.
-    """
-    if not isinstance(string, str):
-        raise TypeError(f'The {name} value must be a string instead of type {type(string)}')
-    if not string and not may_be_empty:
-        raise ValueError(f'The {name} may not be empty')
-
-
-def _validate_web_driver(web_driver: selenium.webdriver.chrome.webdriver.WebDriver) -> None:
-    """Validate a web driver."""
-    if not web_driver:
-        raise TypeError('Web driver can not be of type None')
-    if not isinstance(web_driver, selenium.webdriver.chrome.webdriver.WebDriver):
-        raise TypeError(f'Invalid web_driver data type of {type(web_driver)}')

--- a/jitb/jitb_website.py
+++ b/jitb/jitb_website.py
@@ -15,6 +15,7 @@ from jitb.jbgames.jbg_q3 import JbgQ3
 from jitb.jitb_globals import JITB_POLL_RATE
 from jitb.jitb_logger import Logger
 from jitb.jitb_openai import JitbAi
+from jitb.jitb_validation import validate_game
 
 # List of Jackbox Games that JITB supports
 JITB_SUPPORTED_GAMES: Final[Dict[str, JbgAbc]] = {'Dictionarium': JbgDict, 'Joke Boat': JbgJb,
@@ -42,7 +43,7 @@ def join_room(room_code: str,
     room_code_box = driver.find_element(By.ID, 'roomcode')
     room_code_box.send_keys(room_code)
     game = _verify_room_code(driver)
-    _validate_game(game=game)
+    validate_game(game=game, games=JITB_SUPPORTED_GAMES)
     if username:
         username_box = driver.find_element(By.ID, 'username')
         username_box.send_keys(username)
@@ -64,7 +65,7 @@ def play_the_game(room_code: str, username: str, ai_obj: JitbAi) -> None:
     game, web_driver = join_room(room_code=room_code, username=username)
 
     # SETUP
-    _validate_game(game=game)
+    validate_game(game=game, games=JITB_SUPPORTED_GAMES)
     jbg_obj = JITB_SUPPORTED_GAMES[game](ai_obj=ai_obj, username=username)
 
     # PLAY IT
@@ -78,16 +79,6 @@ def play_the_game(room_code: str, username: str, ai_obj: JitbAi) -> None:
     finally:
         if web_driver:
             web_driver.close()
-
-
-def _validate_game(game: str) -> None:
-    """Validate the game against the dictionary of support games.
-
-    Raises:
-        RuntimeError: This game is not supported.
-    """
-    if game not in JITB_SUPPORTED_GAMES:
-        raise RuntimeError(f'JITB does not yet support {game}')
 
 
 def _verify_room_code(web_driver: selenium.webdriver.chrome.webdriver.WebDriver) -> str:

--- a/test/unit_test/test_jbgdict/test_get_prompt.py
+++ b/test/unit_test/test_jbgdict/test_get_prompt.py
@@ -117,13 +117,13 @@ class ErrorTestJbgDictGetPrompt(TestJbgDictGetPrompt):
     def test_e01_bad_data_type_none(self):
         """Bad Data Type: None."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Bad Data Type: Path object."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgdict/test_id_page.py
+++ b/test/unit_test/test_jbgdict/test_id_page.py
@@ -283,13 +283,13 @@ class ErrorTestJbgDictIdPage(TestJbgDictIdPage):
     def test_e01_bad_data_type_none(self):
         """Bad Data Type: None."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Bad Data Type: Path object."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgjb/test_get_prompt.py
+++ b/test/unit_test/test_jbgjb/test_get_prompt.py
@@ -236,49 +236,48 @@ class ErrorTestJbgJbGetPrompt(TestJbgJbGetPrompt):
     def test_e01_bad_data_type_web_driver_none(self):
         """Bad input: web_driver; None."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_driver_path(self):
         """Bad input: web_driver; Path."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_prompt_clues_string(self):
         """Bad input: prompt_clues; string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_gp_input('JackboxTV-JB-Login_start.html', use_kwarg, 'BAD DATA TYPE', True)
-        self.expect_exception(TypeError, 'Invalid data type for clues')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_prompt_clues_tuple(self):
         """Bad input: prompt_clues; tuple."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_gp_input('JackboxTV-JB-Login_start.html', use_kwarg, ('BAD', 'INPUT'), True)
-        self.expect_exception(TypeError, 'Invalid data type for clues')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_prompt_clues_entry(self):
         """Bad input: prompt_clues; list with a non-string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_gp_input('JackboxTV-JB-Login_start.html', use_kwarg, ['good', 0xBAD], True)
-        self.expect_exception(TypeError,
-                              'The clues list entry value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e06_bad_data_type_clean_string_none(self):
         """Bad input: clean_string; None."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_gp_input('JackboxTV-JB-Login_start.html', use_kwarg, None, None)
-        self.expect_exception(TypeError, 'The clean_string value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_clean_string_string(self):
         """Bad input: clean_string; string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_gp_input('JackboxTV-JB-Login_start.html', use_kwarg, None, 'True')
-        self.expect_exception(TypeError, 'The clean_string value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgjb/test_id_page.py
+++ b/test/unit_test/test_jbgjb/test_id_page.py
@@ -247,13 +247,13 @@ class ErrorTestJbgJbIdPage(TestJbgJbIdPage):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgq2/test_get_last_lash_prompt.py
+++ b/test/unit_test/test_jbgq2/test_get_last_lash_prompt.py
@@ -167,13 +167,13 @@ class ErrorTestJbgQ2GetPrompt(TestJbgQ2GetPrompt):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_jitb_logic_flaw(self):

--- a/test/unit_test/test_jbgq2/test_get_prompt.py
+++ b/test/unit_test/test_jbgq2/test_get_prompt.py
@@ -141,13 +141,13 @@ class ErrorTestJbgQ2GetPrompt(TestJbgQ2GetPrompt):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_jitb_logic_flaw(self):

--- a/test/unit_test/test_jbgq2/test_get_vote_text.py
+++ b/test/unit_test/test_jbgq2/test_get_vote_text.py
@@ -244,13 +244,13 @@ class ErrorTestJbgQ2GetVoteText(TestJbgQ2GetVoteText):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgq2/test_id_page.py
+++ b/test/unit_test/test_jbgq2/test_id_page.py
@@ -138,13 +138,13 @@ class ErrorTestJbgQ2IdPage(TestJbgQ2IdPage):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgq3/test_answer_thriplash.py
+++ b/test/unit_test/test_jbgq3/test_answer_thriplash.py
@@ -66,13 +66,13 @@ class ErrorTestJbgQ3AnswerThriplash(TestJbgQ3AnswerThriplash):
     def test_e01_bad_data_type_web_driver_none(self):
         """Bad input: web_driver; None."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Invalid data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_driver_path(self):
         """Bad input: web_driver; Path."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgq3/test_get_vote_text.py
+++ b/test/unit_test/test_jbgq3/test_get_vote_text.py
@@ -185,49 +185,48 @@ class ErrorTestJbgQ3GetVoteText(TestJbgQ3GetVoteText):
     def test_e01_bad_data_type_web_driver_none(self):
         """Bad input: web_driver; None."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_driver_path(self):
         """Bad input: web_driver; Path."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_vote_clues_string(self):
         """Bad input: vote_clues; string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_test_input('JackboxTV-JB-Login_start.html', use_kwarg, 'BAD DATA TYPE', True)
-        self.expect_exception(TypeError, 'Invalid data type for clues')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_vote_clues_tuple(self):
         """Bad input: vote_clues; tuple."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_test_input('JackboxTV-JB-Login_start.html', use_kwarg, ('BAD', 'INPUT'), True)
-        self.expect_exception(TypeError, 'Invalid data type for clues')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_vote_clues_entry(self):
         """Bad input: vote_clues; list with a non-string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_test_input('JackboxTV-JB-Login_start.html', use_kwarg, ['good', 0xBAD], True)
-        self.expect_exception(TypeError,
-                              'The clues list entry value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e06_bad_data_type_clean_string_none(self):
         """Bad input: clean_string; None."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_test_input('JackboxTV-JB-Login_start.html', use_kwarg, None, None)
-        self.expect_exception(TypeError, 'The clean_string value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_clean_string_string(self):
         """Bad input: clean_string; string."""
         use_kwarg = False  # Tells the test framework how to pass in the input
         self.create_test_input('JackboxTV-JB-Login_start.html', use_kwarg, None, 'True')
-        self.expect_exception(TypeError, 'The clean_string value must be a string instead of type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_jbgq3/test_id_page.py
+++ b/test/unit_test/test_jbgq3/test_id_page.py
@@ -137,13 +137,13 @@ class ErrorTestJbgQ3IdPage(TestJbgQ3IdPage):
     def test_e01_bad_data_type_none(self):
         """Error input that's expected to fail."""
         self.set_test_input(None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_path(self):
         """Error input that's expected to fail."""
         self.set_test_input(Path() / 'test' / 'test_input' / 'JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_openai/test_polish_answer.py
+++ b/test/unit_test/test_openai/test_polish_answer.py
@@ -400,8 +400,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = 'None'  # Test input for the answer argument
         in_limit = 45       # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError,
-                              "Invalid data type for prompt argument: <class 'NoneType'>")
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_prompt_list(self):
@@ -410,7 +409,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = 'None'                               # Test input for the answer argument
         in_limit = 45                                    # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_answer_none(self):
@@ -419,8 +418,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = None    # Test input for the answer argument
         in_limit = 45       # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError,
-                              "Invalid data type for answer argument: <class 'NoneType'>")
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_answer_list(self):
@@ -429,7 +427,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = ['Something']              # Test input for the answer argument
         in_limit = 45                          # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_length_limit_none(self):
@@ -438,8 +436,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = 'N'     # Test input for the answer argument
         in_limit = None     # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError,
-                              'The length_limit argument must be an int')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e06_bad_data_type_length_limit_str(self):
@@ -448,7 +445,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = 'Something'                # Test input for the answer argument
         in_limit = '45'                        # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(TypeError, 'The length_limit argument must be an int')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_value_prompt_empty(self):
@@ -457,7 +454,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = 'Empty'  # Test input for the answer argument
         in_limit = 45        # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(ValueError, 'Prompt may not be empty')
+        self.expect_exception(ValueError, '"prompt" can not be empty')
         self.run_test()
 
     def test_e08_bad_value_answer_empty(self):
@@ -466,7 +463,7 @@ class ErrorTestJitbOpenaiPolishAnswer(TestJitbOpenaiPolishAnswer):
         in_answer = ''       # Test input for the answer argument
         in_limit = 45        # Test input for the length_limit argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, length_limit=in_limit)
-        self.expect_exception(ValueError, 'Answer may not be empty')
+        self.expect_exception(ValueError, '"answer" can not be empty')
         self.run_test()
 
     def test_e09_bad_value_length_limit_negative(self):

--- a/test/unit_test/test_openai/test_remove_answer_overlap.py
+++ b/test/unit_test/test_openai/test_remove_answer_overlap.py
@@ -181,8 +181,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = None    # Test input for the prompt argument
         in_answer = 'None'  # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(TypeError,
-                              "Invalid data type for prompt argument: <class 'NoneType'>")
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_prompt_list(self):
@@ -190,7 +189,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = ['Something', ' ________ ', 'else']  # Test input for the prompt argument
         in_answer = 'None'                               # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_answer_none(self):
@@ -198,8 +197,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = 'None'  # Test input for the prompt argument
         in_answer = None    # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(TypeError,
-                              "Invalid data type for answer argument: <class 'NoneType'>")
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_answer_list(self):
@@ -207,7 +205,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = 'Something ________ else'  # Test input for the prompt argument
         in_answer = ['Something']              # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_value_prompt_empty(self):
@@ -215,7 +213,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = ''       # Test input for the prompt argument
         in_answer = 'Empty'  # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(ValueError, 'Prompt may not be empty')
+        self.expect_exception(ValueError, '"prompt" can not be empty')
         self.run_test()
 
     def test_e06_bad_value_answer_empty(self):
@@ -223,7 +221,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_prompt = 'Empty'  # Test input for the prompt argument
         in_answer = ''       # Test input for the answer argument
         self.set_test_input(prompt=in_prompt, answer=in_answer)
-        self.expect_exception(ValueError, 'Answer may not be empty')
+        self.expect_exception(ValueError, '"answer" can not be empty')
         self.run_test()
 
     def test_e07_bad_data_type_min_len_none(self):
@@ -232,8 +230,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_answer = 'None'                     # Test input for the answer argument
         in_min_len = None                      # Test input for the min_len argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, min_len=in_min_len)
-        self.expect_exception(TypeError,
-                              "Invalid data type for min_len argument: <class 'NoneType'>")
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e08_bad_data_type_min_len_str(self):
@@ -242,7 +239,7 @@ class ErrorTestJitbOpenaiRemoveAnswerOverlap(TestJitbOpenaiRemoveAnswerOverlap):
         in_answer = 'None'                     # Test input for the answer argument
         in_min_len = '4'                       # Test input for the min_len argument
         self.set_test_input(prompt=in_prompt, answer=in_answer, min_len=in_min_len)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e09_bad_value_min_len_zero(self):

--- a/test/unit_test/test_selenium/test_get_buttons.py
+++ b/test/unit_test/test_selenium/test_get_buttons.py
@@ -170,13 +170,13 @@ class ErrorTestJitbSeleniumGetButtons(TestJitbSeleniumGetButtons):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_selenium/test_get_sub_buttons.py
+++ b/test/unit_test/test_selenium/test_get_sub_buttons.py
@@ -234,25 +234,25 @@ class ErrorTestJitbSeleniumGetSubButtons(TestJitbSeleniumGetSubButtons):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_by_none(self):
         """Bad data type: sub_by == None."""
         self.set_buttons_input(filename='JackboxTV-login_start.html', in_by=None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_by_package_enum(self):
         """Bad data type: sub_by == By."""
         self.set_buttons_input(filename='JackboxTV-login_start.html', in_by=By)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_by_enum_literal(self):
@@ -265,13 +265,13 @@ class ErrorTestJitbSeleniumGetSubButtons(TestJitbSeleniumGetSubButtons):
     def test_e06_bad_data_type_value_list(self):
         """Bad data type: sub_value == []."""
         self.set_buttons_input(filename='JackboxTV-login_start.html', in_value=[])
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_value_bytes(self):
         """Bad data type: sub_value == b''."""
         self.set_buttons_input(filename='JackboxTV-login_start.html', in_value=b'find-this')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 
@@ -289,25 +289,25 @@ class SpecialTestJitbSeleniumGetSubButtons(TestJitbSeleniumGetSubButtons):
     def test_s01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_s02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_s03_bad_data_type_by_none(self):
         """Bad data type: sub_by == None."""
         self.set_buttons_input_kwargs(filename='JackboxTV-login_start.html', in_by=None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_s04_bad_data_type_by_package_enum(self):
         """Bad data type: sub_by == By."""
         self.set_buttons_input_kwargs(filename='JackboxTV-login_start.html', in_by=By)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_s05_bad_data_type_by_enum_literal(self):
@@ -320,13 +320,13 @@ class SpecialTestJitbSeleniumGetSubButtons(TestJitbSeleniumGetSubButtons):
     def test_s06_bad_data_type_value_list(self):
         """Bad data type: sub_value == []."""
         self.set_buttons_input_kwargs(filename='JackboxTV-login_start.html', in_value=[])
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_s07_bad_data_type_value_bytes(self):
         """Bad data type: sub_value == b''."""
         self.set_buttons_input_kwargs(filename='JackboxTV-login_start.html', in_value=b'find-this')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_selenium/test_get_sub_element.py
+++ b/test/unit_test/test_selenium/test_get_sub_element.py
@@ -195,13 +195,13 @@ class ErrorTestJitbSeleniumGetElement(TestJitbSeleniumGetElement):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_element == None."""
         self.set_test_input(web_element=None)
-        self.expect_exception(TypeError, 'Web element may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_element == Path()."""
         self.set_test_input(web_element=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_by_none(self):
@@ -209,7 +209,7 @@ class ErrorTestJitbSeleniumGetElement(TestJitbSeleniumGetElement):
         self.set_test_input(
             web_element=self.get_element_input(filename='JackboxTV-login_start.html',
                                                value='app'), by_arg=None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_by_package_enum(self):
@@ -217,7 +217,7 @@ class ErrorTestJitbSeleniumGetElement(TestJitbSeleniumGetElement):
         self.set_test_input(
             web_element=self.get_element_input(filename='JackboxTV-login_start.html',
                                                value='app'), by_arg=By)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_by_enum_literal(self):
@@ -234,7 +234,7 @@ class ErrorTestJitbSeleniumGetElement(TestJitbSeleniumGetElement):
         self.set_test_input(
             web_element=self.get_element_input(filename='JackboxTV-login_start.html',
                                                value='app'), value=[])
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_value_bytes(self):
@@ -242,7 +242,7 @@ class ErrorTestJitbSeleniumGetElement(TestJitbSeleniumGetElement):
         self.set_test_input(
             web_element=self.get_element_input(filename='JackboxTV-login_start.html',
                                                value='app'), value=b'find-this')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_selenium/test_get_web_element.py
+++ b/test/unit_test/test_selenium/test_get_web_element.py
@@ -133,27 +133,27 @@ class ErrorTestJitbSeleniumGetWebElement(TestJitbSeleniumGetWebElement):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_by_none(self):
         """Bad data type: by == None."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, by_arg=None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_by_package_enum(self):
         """Bad data type: by == By."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, by_arg=By)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_by_enum_literal(self):
@@ -168,14 +168,14 @@ class ErrorTestJitbSeleniumGetWebElement(TestJitbSeleniumGetWebElement):
         """Bad data type: value == []."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, value=[])
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_value_bytes(self):
         """Bad data type: value == b''."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, value=b'find-this')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_selenium/test_get_web_element_text.py
+++ b/test/unit_test/test_selenium/test_get_web_element_text.py
@@ -134,27 +134,27 @@ class ErrorTestJitbSeleniumGetWebElementText(TestJitbSeleniumGetWebElementText):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver may not be None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e03_bad_data_type_by_none(self):
         """Bad data type: by_arg == None."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, by_arg=None)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e04_bad_data_type_by_package_enum(self):
         """Bad data type: by_arg == By."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, by_arg=By)
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e05_bad_data_type_by_enum_literal(self):
@@ -169,14 +169,14 @@ class ErrorTestJitbSeleniumGetWebElementText(TestJitbSeleniumGetWebElementText):
         """Bad data type: value == []."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, value=[])
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e07_bad_data_type_value_bytes(self):
         """Bad data type: value == b''."""
         self.create_web_driver(filename='JackboxTV-login_start.html')
         self.set_test_input(web_driver=self.web_driver, value=b'find-this')
-        self.expect_exception(TypeError, 'Invalid data type')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 

--- a/test/unit_test/test_webdriver/test_get_button_choices.py
+++ b/test/unit_test/test_webdriver/test_get_button_choices.py
@@ -201,13 +201,13 @@ class ErrorTestJitbWebdriverGetButtonChoices(TestJitbWebdriverGetButtonChoices):
     def test_e01_bad_data_type_web_element_none(self):
         """Bad data type: web_driver == None."""
         self.set_test_input(web_driver=None)
-        self.expect_exception(TypeError, 'Web driver can not be of type None')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
     def test_e02_bad_data_type_web_element_path(self):
         """Bad data type: web_driver == Path()."""
         self.set_test_input(web_driver=Path() / 'test/test_input/JackboxTV-login_start.html')
-        self.expect_exception(TypeError, 'Invalid web_driver data type of ')
+        self.expect_exception(TypeError, 'expected type')
         self.run_test()
 
 


### PR DESCRIPTION
Removed a bunch of tech debt by refactoring JITB input validation into a single point of truth (SPOT).
Also, if we're gonna use HOLLOW BOOMER (HOBO) then let's use `hobo`.  Maximized usage of HOBO's `hobo.validation` module.
Finally, updated the test cases with new string literals to expect from failed validation.